### PR TITLE
chore: remove base64 decoding in endpoints

### DIFF
--- a/src/main/java/pl/poznan/put/rnapdbee/engine/calculation/control/CalculationController.java
+++ b/src/main/java/pl/poznan/put/rnapdbee/engine/calculation/control/CalculationController.java
@@ -53,6 +53,16 @@ public class CalculationController {
         throw new UnsupportedOperationException();
     }
 
+    /**
+     * Endpoint responsible for 2D -> (....) analysis.
+     *
+     * @param structuralElementsHandling enum determining if pseudoknots should be considered or not
+     * @param visualizationTool          enum for Visualization Tool
+     * @param removeIsolated             boolean value indicating if the isolated residues should be removed or not
+     * @param contentDispositionHeader   Content-Disposition header containing name of the file
+     * @param fileContent                content of the analysed file
+     * @return wrapped in an object list of image outputs
+     */
     @Operation(summary = "Perform a 2D to Dot-Bracket calculation")
     @PostMapping(path = "/2d", produces = "application/json", consumes = "text/plain")
     public ResponseEntity<Output2D> calculateSecondaryToDotBracket(
@@ -60,18 +70,17 @@ public class CalculationController {
             @RequestParam("visualizationTool") VisualizationTool visualizationTool,
             @RequestParam("removeIsolated") boolean removeIsolated,
             @RequestHeader("Content-Disposition") String contentDispositionHeader,
-            @RequestBody String encodedContent) {
+            @RequestBody String fileContent) {
 
         logger.info(String.format("Analysis of scenario 2D -> (...) started for content-disposition header %s",
                 contentDispositionHeader));
         ContentDisposition contentDisposition = ContentDisposition.parse(contentDispositionHeader);
-        String decodedContent = EncodingUtils.decodeBase64ToString(encodedContent);
         var outputAnalysis = calculationService
                 .handleSecondaryToDotBracketCalculation(
                         structuralElementsHandling,
                         visualizationTool,
                         removeIsolated,
-                        decodedContent,
+                        fileContent,
                         contentDisposition.getFilename());
         return new ResponseEntity<>(outputAnalysis, HttpStatus.OK);
     }
@@ -88,11 +97,11 @@ public class CalculationController {
     }
 
     /**
-     * Endpoint responsible for (...) -> Image analysis.
+     * Endpoint responsible for (....) -> Image analysis.
      *
      * @param structuralElementsHandling enum determining if pseudoknots should be considered or not
      * @param visualizationTool          enum for Visualization Tool
-     * @param encodedContent             base64 encoded content of the uploaded file
+     * @param fileContent                content of the analysed file
      * @return wrapped in an object list of image outputs
      */
     @Operation(summary = "Perform a Dot-Bracket to Image calculation")
@@ -101,17 +110,16 @@ public class CalculationController {
             @RequestParam("structuralElementsHandling") StructuralElementsHandling structuralElementsHandling,
             @RequestParam("visualizationTool") VisualizationTool visualizationTool,
             @RequestHeader("Content-Disposition") String contentDispositionHeader,
-            @RequestBody String encodedContent) {
+            @RequestBody String fileContent) {
 
         logger.info(String.format("Analysis of scenario (...) -> Image started for content-disposition header %s",
                 contentDispositionHeader));
         ContentDisposition contentDisposition = ContentDisposition.parse(contentDispositionHeader);
-        String decodedContent = EncodingUtils.decodeBase64ToString(encodedContent);
         var outputAnalysis = calculationService
                 .handleDotBracketToImageCalculation(
                         structuralElementsHandling,
                         visualizationTool,
-                        decodedContent,
+                        fileContent,
                         contentDisposition.getFilename());
         return new ResponseEntity<>(outputAnalysis, HttpStatus.OK);
     }

--- a/src/main/java/pl/poznan/put/rnapdbee/engine/calculation/model/Output2D.java
+++ b/src/main/java/pl/poznan/put/rnapdbee/engine/calculation/model/Output2D.java
@@ -7,6 +7,8 @@ import java.util.List;
  * DTO class representing response body secondary structure analysis.
  * Relevant for "(...) -> image" and "2D -> (...)" scenarios.
  */
+// TODO:
+//  There should not be an array of analysis here, only single one. To be discussed on how should it be handled
 public class Output2D {
 
     private List<SingleSecondaryModelAnalysisOutput> analysis;

--- a/src/test/java/pl/poznan/put/rnapdbee/engine/calculation/control/CalculationControllerTest.java
+++ b/src/test/java/pl/poznan/put/rnapdbee/engine/calculation/control/CalculationControllerTest.java
@@ -61,86 +61,73 @@ class CalculationControllerTest {
 
     @Test
     public void shouldPopulateResponseEntityWithTheMappedResponseWhenTheCalculateDBToImageCalculationIsSuccessful() {
-        // creating mocked scope in which static methods are mocked ones
-        try (MockedStatic<EncodingUtils> mockedEncodingUtils = Mockito.mockStatic(EncodingUtils.class)) {
-            var analysisOutput = provideMockedOutput2D();
-            var expectedSingleAnalysis = analysisOutput.getAnalysis().get(0);
-            // mocked
-            mockedEncodingUtils.when(() -> EncodingUtils.decodeBase64ToString(Mockito.any())).
-                    thenReturn(mockedContent);
+        var analysisOutput = provideMockedOutput2D();
+        var expectedSingleAnalysis = analysisOutput.getAnalysis().get(0);
+        // mocked
+        Mockito.when(calculationService.handleDotBracketToImageCalculation(Mockito.any(),
+                        Mockito.any(), Mockito.eq(mockedContent), Mockito.eq(mockedFilename)))
+                .thenReturn(analysisOutput);
+        // when
+        ResponseEntity<Output2D> response = cut
+                .calculateDotBracketToImage(null, null,
+                        "Attachment; filename=\"" + mockedFilename + "\"", mockedContent);
+        // then
+        var actualSingleAnalysis = Objects.requireNonNull(response.getBody()).getAnalysis().get(0);
+        Assertions.assertEquals(HttpStatus.OK, response.getStatusCode());
+        Assertions.assertEquals(expectedSingleAnalysis.getBpSeq(), actualSingleAnalysis.getBpSeq());
+        Assertions.assertEquals(expectedSingleAnalysis.getCt(), actualSingleAnalysis.getCt());
+        Assertions.assertEquals(expectedSingleAnalysis.getInteractions(), actualSingleAnalysis.getInteractions());
 
-            Mockito.when(calculationService.handleDotBracketToImageCalculation(Mockito.any(),
-                            Mockito.any(), Mockito.eq(mockedContent), Mockito.eq(mockedFilename)))
-                    .thenReturn(analysisOutput);
+        Assertions.assertEquals(expectedSingleAnalysis.getStrands().get(0).getName(), actualSingleAnalysis.getStrands().get(0).getName());
+        Assertions.assertEquals(expectedSingleAnalysis.getStrands().get(0).getSequence(), actualSingleAnalysis.getStrands().get(0).getSequence());
+        Assertions.assertEquals(expectedSingleAnalysis.getStrands().get(0).getStructure(), actualSingleAnalysis.getStrands().get(0).getStructure());
 
-            // when
-            ResponseEntity<Output2D> response = cut
-                    .calculateDotBracketToImage(null, null,
-                            "Attachment; filename=\"" + mockedFilename + "\"", mockedContent);
-            // then
-            var actualSingleAnalysis = Objects.requireNonNull(response.getBody()).getAnalysis().get(0);
-            Assertions.assertEquals(HttpStatus.OK, response.getStatusCode());
-            Assertions.assertEquals(expectedSingleAnalysis.getBpSeq(), actualSingleAnalysis.getBpSeq());
-            Assertions.assertEquals(expectedSingleAnalysis.getCt(), actualSingleAnalysis.getCt());
-            Assertions.assertEquals(expectedSingleAnalysis.getInteractions(), actualSingleAnalysis.getInteractions());
+        Assertions.assertEquals(expectedSingleAnalysis.getStructuralElements().getSingleStrands(), actualSingleAnalysis.getStructuralElements().getSingleStrands());
+        Assertions.assertEquals(expectedSingleAnalysis.getStructuralElements().getSingleStrands5p(), actualSingleAnalysis.getStructuralElements().getSingleStrands5p());
+        Assertions.assertEquals(expectedSingleAnalysis.getStructuralElements().getSingleStrands3p(), actualSingleAnalysis.getStructuralElements().getSingleStrands3p());
+        Assertions.assertEquals(expectedSingleAnalysis.getStructuralElements().getLoops(), actualSingleAnalysis.getStructuralElements().getLoops());
+        Assertions.assertEquals(expectedSingleAnalysis.getStructuralElements().getStems(), actualSingleAnalysis.getStructuralElements().getStems());
 
-            Assertions.assertEquals(expectedSingleAnalysis.getStrands().get(0).getName(), actualSingleAnalysis.getStrands().get(0).getName());
-            Assertions.assertEquals(expectedSingleAnalysis.getStrands().get(0).getSequence(), actualSingleAnalysis.getStrands().get(0).getSequence());
-            Assertions.assertEquals(expectedSingleAnalysis.getStrands().get(0).getStructure(), actualSingleAnalysis.getStrands().get(0).getStructure());
-
-            Assertions.assertEquals(expectedSingleAnalysis.getStructuralElements().getSingleStrands(), actualSingleAnalysis.getStructuralElements().getSingleStrands());
-            Assertions.assertEquals(expectedSingleAnalysis.getStructuralElements().getSingleStrands5p(), actualSingleAnalysis.getStructuralElements().getSingleStrands5p());
-            Assertions.assertEquals(expectedSingleAnalysis.getStructuralElements().getSingleStrands3p(), actualSingleAnalysis.getStructuralElements().getSingleStrands3p());
-            Assertions.assertEquals(expectedSingleAnalysis.getStructuralElements().getLoops(), actualSingleAnalysis.getStructuralElements().getLoops());
-            Assertions.assertEquals(expectedSingleAnalysis.getStructuralElements().getStems(), actualSingleAnalysis.getStructuralElements().getStems());
-
-            Assertions.assertEquals(expectedSingleAnalysis.getImageInformation().getFailedDrawer(), actualSingleAnalysis.getImageInformation().getFailedDrawer());
-            Assertions.assertEquals(expectedSingleAnalysis.getImageInformation().getSuccessfulDrawer(), actualSingleAnalysis.getImageInformation().getSuccessfulDrawer());
-            Assertions.assertEquals(expectedSingleAnalysis.getImageInformation().getPathToPNGImage(), actualSingleAnalysis.getImageInformation().getPathToPNGImage());
-            Assertions.assertEquals(expectedSingleAnalysis.getImageInformation().getPathToSVGImage(), actualSingleAnalysis.getImageInformation().getPathToSVGImage());
-        }
+        Assertions.assertEquals(expectedSingleAnalysis.getImageInformation().getFailedDrawer(), actualSingleAnalysis.getImageInformation().getFailedDrawer());
+        Assertions.assertEquals(expectedSingleAnalysis.getImageInformation().getSuccessfulDrawer(), actualSingleAnalysis.getImageInformation().getSuccessfulDrawer());
+        Assertions.assertEquals(expectedSingleAnalysis.getImageInformation().getPathToPNGImage(), actualSingleAnalysis.getImageInformation().getPathToPNGImage());
+        Assertions.assertEquals(expectedSingleAnalysis.getImageInformation().getPathToSVGImage(), actualSingleAnalysis.getImageInformation().getPathToSVGImage());
     }
 
 
     @Test
     public void shouldPopulateResponseEntityWithTheMappedResponseWhenTheCalculateSecondaryToDotBracketCalculationIsSuccessful() {
-        // creating mocked scope in which static methods are mocked ones
-        try (MockedStatic<EncodingUtils> mockedEncodingUtils = Mockito.mockStatic(EncodingUtils.class)) {
-            var analysisOutput = provideMockedOutput2D();
-            var expectedSingleAnalysis = analysisOutput.getAnalysis().get(0);
-            // mocked
-            mockedEncodingUtils.when(() -> EncodingUtils.decodeBase64ToString(Mockito.any())).
-                    thenReturn(mockedContent);
-            Mockito.when(calculationService.handleSecondaryToDotBracketCalculation(Mockito.any(),
-                            Mockito.any(), Mockito.eq(true), Mockito.eq(mockedContent), Mockito.eq(mockedFilename)))
-                    .thenReturn(analysisOutput);
+        var analysisOutput = provideMockedOutput2D();
+        var expectedSingleAnalysis = analysisOutput.getAnalysis().get(0);
+        // mocked
+        Mockito.when(calculationService.handleSecondaryToDotBracketCalculation(Mockito.any(),
+                        Mockito.any(), Mockito.eq(true), Mockito.eq(mockedContent), Mockito.eq(mockedFilename)))
+                .thenReturn(analysisOutput);
+        // when
+        ResponseEntity<Output2D> response = cut
+                .calculateSecondaryToDotBracket(null, null, true,
+                        "Attachment; filename=\"" + mockedFilename + "\"", mockedContent);
+        // then
+        var actualSingleAnalysis = Objects.requireNonNull(response.getBody()).getAnalysis().get(0);
+        Assertions.assertEquals(HttpStatus.OK, response.getStatusCode());
+        Assertions.assertEquals(expectedSingleAnalysis.getBpSeq(), actualSingleAnalysis.getBpSeq());
+        Assertions.assertEquals(expectedSingleAnalysis.getCt(), actualSingleAnalysis.getCt());
+        Assertions.assertEquals(expectedSingleAnalysis.getInteractions(), actualSingleAnalysis.getInteractions());
 
-            // when
-            ResponseEntity<Output2D> response = cut
-                    .calculateSecondaryToDotBracket(null, null, true,
-                            "Attachment; filename=\"" + mockedFilename + "\"", mockedContent);
-            // then
-            var actualSingleAnalysis = Objects.requireNonNull(response.getBody()).getAnalysis().get(0);
-            Assertions.assertEquals(HttpStatus.OK, response.getStatusCode());
-            Assertions.assertEquals(expectedSingleAnalysis.getBpSeq(), actualSingleAnalysis.getBpSeq());
-            Assertions.assertEquals(expectedSingleAnalysis.getCt(), actualSingleAnalysis.getCt());
-            Assertions.assertEquals(expectedSingleAnalysis.getInteractions(), actualSingleAnalysis.getInteractions());
+        Assertions.assertEquals(expectedSingleAnalysis.getStrands().get(0).getName(), actualSingleAnalysis.getStrands().get(0).getName());
+        Assertions.assertEquals(expectedSingleAnalysis.getStrands().get(0).getSequence(), actualSingleAnalysis.getStrands().get(0).getSequence());
+        Assertions.assertEquals(expectedSingleAnalysis.getStrands().get(0).getStructure(), actualSingleAnalysis.getStrands().get(0).getStructure());
 
-            Assertions.assertEquals(expectedSingleAnalysis.getStrands().get(0).getName(), actualSingleAnalysis.getStrands().get(0).getName());
-            Assertions.assertEquals(expectedSingleAnalysis.getStrands().get(0).getSequence(), actualSingleAnalysis.getStrands().get(0).getSequence());
-            Assertions.assertEquals(expectedSingleAnalysis.getStrands().get(0).getStructure(), actualSingleAnalysis.getStrands().get(0).getStructure());
+        Assertions.assertEquals(expectedSingleAnalysis.getStructuralElements().getSingleStrands(), actualSingleAnalysis.getStructuralElements().getSingleStrands());
+        Assertions.assertEquals(expectedSingleAnalysis.getStructuralElements().getSingleStrands5p(), actualSingleAnalysis.getStructuralElements().getSingleStrands5p());
+        Assertions.assertEquals(expectedSingleAnalysis.getStructuralElements().getSingleStrands3p(), actualSingleAnalysis.getStructuralElements().getSingleStrands3p());
+        Assertions.assertEquals(expectedSingleAnalysis.getStructuralElements().getLoops(), actualSingleAnalysis.getStructuralElements().getLoops());
+        Assertions.assertEquals(expectedSingleAnalysis.getStructuralElements().getStems(), actualSingleAnalysis.getStructuralElements().getStems());
 
-            Assertions.assertEquals(expectedSingleAnalysis.getStructuralElements().getSingleStrands(), actualSingleAnalysis.getStructuralElements().getSingleStrands());
-            Assertions.assertEquals(expectedSingleAnalysis.getStructuralElements().getSingleStrands5p(), actualSingleAnalysis.getStructuralElements().getSingleStrands5p());
-            Assertions.assertEquals(expectedSingleAnalysis.getStructuralElements().getSingleStrands3p(), actualSingleAnalysis.getStructuralElements().getSingleStrands3p());
-            Assertions.assertEquals(expectedSingleAnalysis.getStructuralElements().getLoops(), actualSingleAnalysis.getStructuralElements().getLoops());
-            Assertions.assertEquals(expectedSingleAnalysis.getStructuralElements().getStems(), actualSingleAnalysis.getStructuralElements().getStems());
-
-            Assertions.assertEquals(expectedSingleAnalysis.getImageInformation().getFailedDrawer(), actualSingleAnalysis.getImageInformation().getFailedDrawer());
-            Assertions.assertEquals(expectedSingleAnalysis.getImageInformation().getSuccessfulDrawer(), actualSingleAnalysis.getImageInformation().getSuccessfulDrawer());
-            Assertions.assertEquals(expectedSingleAnalysis.getImageInformation().getPathToPNGImage(), actualSingleAnalysis.getImageInformation().getPathToPNGImage());
-            Assertions.assertEquals(expectedSingleAnalysis.getImageInformation().getPathToSVGImage(), actualSingleAnalysis.getImageInformation().getPathToSVGImage());
-        }
+        Assertions.assertEquals(expectedSingleAnalysis.getImageInformation().getFailedDrawer(), actualSingleAnalysis.getImageInformation().getFailedDrawer());
+        Assertions.assertEquals(expectedSingleAnalysis.getImageInformation().getSuccessfulDrawer(), actualSingleAnalysis.getImageInformation().getSuccessfulDrawer());
+        Assertions.assertEquals(expectedSingleAnalysis.getImageInformation().getPathToPNGImage(), actualSingleAnalysis.getImageInformation().getPathToPNGImage());
+        Assertions.assertEquals(expectedSingleAnalysis.getImageInformation().getPathToSVGImage(), actualSingleAnalysis.getImageInformation().getPathToSVGImage());
     }
 
 


### PR DESCRIPTION
Base64 decoding has been removed since we are accepting text/plain objects, so the information won't be encoded anyway.